### PR TITLE
[WIP] Avoid copy and memory usage in parsing script.

### DIFF
--- a/scripts/parse_xml.py
+++ b/scripts/parse_xml.py
@@ -18,7 +18,7 @@ for filename in filenames:
     except Exception as e:
         print(e)
 
-data = pd.concat(data, copy=False)  # Because the input data is a list of DataFrames, this saves a LOT of memory!
+data = pd.concat(data, copy=False, ignore_index=True)  # Because the input data is a list of DataFrames, this saves a LOT of memory!  Ignore the index to return unique index.
 data.to_hdf("./data.h5", 'data')
 
 compound_dict = pd.Series(compound_dict)

--- a/scripts/parse_xml.py
+++ b/scripts/parse_xml.py
@@ -2,22 +2,24 @@ import pandas as pd
 import glob, os
 from thermopyl import Parser
 
-XML_PATH = os.path.join(os.environ["HOME"], "dat/thermo")
+XML_PATH = os.path.join(os.environ["HOME"], "dat/thermoml_data/")
+filenames = glob.glob("%s/ThermoML/*/*.xml" % XML_PATH)
 
 data = []
 compound_dict = {}
-for filename in glob.glob("%s/*/*.xml" % XML_PATH):
+for filename in filenames:
     print(filename)
     try:
         parser = Parser(filename)
         current_data = parser.parse()
-        data.extend(current_data)
+        current_data = pd.DataFrame(current_data)
+        data.append(current_data)
         compound_dict.update(parser.compound_name_to_formula)
     except Exception as e:
         print(e)
 
-data = pd.DataFrame(data)
-compound_dict = pd.Series(compound_dict)
-
+data = pd.concat(data, copy=False)  # Because the input data is a list of DataFrames, this saves a LOT of memory!
 data.to_hdf("./data.h5", 'data')
+
+compound_dict = pd.Series(compound_dict)
 compound_dict.to_hdf("./compound_name_to_formula.h5", 'data')

--- a/scripts/parse_xml.py
+++ b/scripts/parse_xml.py
@@ -2,7 +2,7 @@ import pandas as pd
 import glob, os
 from thermopyl import Parser
 
-XML_PATH = os.path.join(os.environ["HOME"], "dat/thermoml_data/")
+XML_PATH = os.environ["THERMOML_PATH"]
 filenames = glob.glob("%s/ThermoML/*/*.xml" % XML_PATH)
 
 data = []

--- a/scripts/parse_xml.py
+++ b/scripts/parse_xml.py
@@ -19,7 +19,7 @@ for filename in filenames:
         print(e)
 
 data = pd.concat(data, copy=False, ignore_index=True)  # Because the input data is a list of DataFrames, this saves a LOT of memory!  Ignore the index to return unique index.
-data.to_hdf("./data.h5", 'data')
+data.to_hdf("%s/data.h5" % XML_PATH, 'data')
 
 compound_dict = pd.Series(compound_dict)
-compound_dict.to_hdf("./compound_name_to_formula.h5", 'data')
+compound_dict.to_hdf("%s/compound_name_to_formula.h5" % XML_PATH, 'data')


### PR DESCRIPTION
These adjustments should prevent a huge memory usage spike when constructing the Pandas DataFrame object.  Current pull is being run on latest ThermoML archive. 