### PR TITLE
Speed up travis tests

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -33,9 +33,9 @@ test:
     - thermopyl
   commands:
     - nosetests thermopyl --nocapture --verbosity=2 --with-doctest
-    - which thermoml-update-mirror
     - thermoml-update-mirror
-    - thermoml-build-pandas
+    - thermoml-build-pandas --help
+    - thermoml-build-pandas --journalprefix=acs
 
 about:
   home: https://github.com/choderalab/thermopyl

--- a/thermopyl/scripts/parse_xml.py
+++ b/thermopyl/scripts/parse_xml.py
@@ -6,15 +6,31 @@ Parse ThermoML XML files in the local ThermoML Archive mirror.
 import pandas as pd
 import glob, os, os.path
 from thermopyl import Parser
+import argparse
 
 def main():
-    try:
+    # Parse command-line arguments.
+    parser = argparse.ArgumentParser(description='Build a Pandas dataset from local ThermoML Archive mirror.')
+    parser.add_argument('--journalprefix', dest='journalprefix', metavar='JOURNALPREFIX', action='store', type=str, default=None,
+                        help='journal prefix to use in globbing *.xml files')
+    parser.add_argument('--path', dest='path', metavar='path', action='store', type=str, default=None,
+                        help='path to local ThermoML Archive mirror')
+    args = parser.parse_args()
+
+    # Get location of local ThermoML Archive mirror.
+    XML_PATH = os.path.join(os.environ["HOME"], '.thermoml') # DEFAULT LOCATION
+    if args.path != None:
+        XML_PATH = args['path']
+    elif 'THERMOML_PATH' in os.environ:
         XML_PATH = os.environ["THERMOML_PATH"]
-    except:
-        XML_PATH = os.path.join(os.environ["HOME"], '.thermoml')
 
-    filenames = glob.glob("%s/*.xml" % XML_PATH)
+    # Get path for XML files.
+    if args.journalprefix != None:
+        filenames = glob.glob("%s/%s*.xml" % (XML_PATH, args.journalprefix))
+    else:
+        filenames = glob.glob("%s/*.xml" % XML_PATH)
 
+    # Process data.
     data = []
     compound_dict = {}
     for filename in filenames:


### PR DESCRIPTION
* Added `--path` option to `parse_xml` to allow path to be specified via command line
* Added `--journalprefix` option to `parse_xml` to allow only a subset of journal XML data to be consolidated into pandas
* Changed travis tests to use only `acs` prefix to speed up tests