### PR TITLE
Fix binstar package name

### DIFF
--- a/devtools/travis-ci/after_success.sh
+++ b/devtools/travis-ci/after_success.sh
@@ -15,7 +15,7 @@ fi
 
 
 # Deploy to binstar
-conda install --yes conda-server jinja2
+conda install --yes anaconda-client jinja2
 binstar -t $BINSTAR_TOKEN upload --force -u choderalab -p ${PACKAGENAME}-dev $HOME/miniconda/conda-bld/*/${PACKAGENAME}-dev-*.tar.bz2
 
 if [ $PUSH_DOCS_TO_S3 = true ]; then


### PR DESCRIPTION
This fixes the binstar package name (now called `anaconda-client`) to get `ThermoPyL-dev` to upload correctly.